### PR TITLE
ci(.github): Add GitHub Actions workflow to link issue to PR

### DIFF
--- a/.github/workflows/link-issue-to-pr.yaml
+++ b/.github/workflows/link-issue-to-pr.yaml
@@ -1,0 +1,26 @@
+name: Link Issue to PR
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  link-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Issue Number from Branch Name
+        id: extract
+        run: echo "::set-output name=issue_number::$(echo ${{ github.head_ref }} | grep -o -E '^\d+')"
+      - name: Link Issue in PR
+        if: steps.extract.outputs.issue_number != ''
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueNumber = ${{ steps.extract.outputs.issue_number }};
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: `Linked to PR: #${{ github.event.pull_request.number }}`
+            });

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "workbench.preferredDarkColorTheme": "Default Dark Modern",
+  "workbench.colorTheme": "Abyss"
+}


### PR DESCRIPTION
## 概要
ブランチ名の末尾からissue番号を抽出し、そのissueにコメントを追加してPRとリンクするためのGitHub Actionsワークフローを作成しました。