### PR TITLE
ci(.github): Add Preview workflow

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,43 @@
+name: Preview
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/README.md'
+
+jobs:
+  nx-affected:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: 18
+          pnpm-version: 8.7.5
+      - run: pnpm install --frozen-lockfile
+
+      - uses: nrwl/nx-set-shas@v3
+
+      - run: git branch --track main origin/main
+
+      - name: nx affected
+        run: npx nx format:check
+          npx nx affected -t lint,test,build --parallel=3
+
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   needs: nx-affected
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Deploy to Vercel
+  #       run: npx vercel deploy --token ${{ secrets.VERCEL_TOKEN }} --prod
+  #       env:
+  #         VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  #         VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
# 概要
nx affectedでlint, test, buildに成功したらデプロイ開始、というフローを構築したかった。
が、以下のようにVercelのデフォルト機能の多くをoffすることになり、イマイチに感じたため作戦を変更。
- PRへのコメントをoff
- PR作成したらPreview環境へのデプロイをoff
- nx ignoreも使わなくなる

いったんはデフォルトの挙動でPreview環境にデプロイさせる。
nx ignoreを使って、Vercel上でビルドするか否かの判断をさせる。
#21 で設定したように、nx affectedに失敗したらPRのmergeはブロックする。
という運用でごまかしてみる。

ただ、これだとVercel上のnx ignoreとGitHub Actions上のnx affectedが両方動くようになっており、
整合性が取れているのかという面で不安が残る。

## Issue Number

Close #16 

## 関連リンク

- [Issue](https://github.com/rysiva/blog-workspace/issues/16)

## チェックリスト

- [ ] check something...

## 補足情報
<!-- その他、レビュワーに伝えたい情報があれば記載してください。 -->
